### PR TITLE
References update 2

### DIFF
--- a/lcdb/lcdb-init.py
+++ b/lcdb/lcdb-init.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python
+
+import os
+import logging
+import argparse
+import subprocess as sp
+import sys
+
+logging.basicConfig(level=logging.DEBUG)
+logger = logging.getLogger(os.path.basename(__file__))
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BLUE = '\033[94m'
+GREEN = '\033[92m'
+YELLOW = '\033[93m'
+RED = '\033[91m'
+ENDC = '\033[0m'
+
+
+def run(cmds, **kwargs):
+    """
+    Print commands in blue before running them. kwargs are passed to
+    subprocess.check_call.
+    """
+    logger.info(BLUE + ' '.join(cmds) + ENDC)
+    sp.check_call(cmds, **kwargs)
+
+
+def clone(dest, label, repo=None):
+    if repo is None:
+        repo = 'git@github.com:lcdb/lcdb-workflows.git'
+    if os.path.exists(dest):
+        print(RED + dest + ' already exists, aborting' + ENDC)
+        sys.exit(1)
+    run(['git', 'clone', repo, dest])
+    run(['git', 'checkout', '-b', label], cwd=dest)
+    generate_config(dest)
+    run(['git', 'add', 'config.yaml'], cwd=dest)
+    run(['git', 'commit', '-m', '"initialization of %s"' % label], cwd=dest)
+
+
+def build_env(repo, label):
+    run([
+
+        'conda', 'create', '-n', label,
+        '--file', os.path.join(repo, 'test', 'requirements.txt'),
+        '-c', 'bioconda', '-c', 'r', 'python=3'
+    ])
+
+
+def generate_config(dest):
+    """
+    Sets up configuration. Eventually this will build a config file based on
+    the schema.
+    """
+    # TODO: lots more to add here; currently just creates something to commit.
+    run(['touch', 'config.yaml'], cwd=dest)
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser()
+    ap.add_argument(
+        '--dest', default='.',
+        help='Destination directory in which to clone workflows')
+    ap.add_argument(
+        '--label',
+        help='Label for experiment. Will be used for git branch and conda '
+        'environment.')
+    ap.add_argument(
+        '--no-build-env', action='store_true',
+        help="Don't build a new environment")
+    args = ap.parse_args()
+    clone(args.dest, args.label)
+    if not args.no_build_env:
+        build_env(args.dest, args.label)

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -12,3 +12,4 @@ bowtie2>=2.2.8
 picard>=2.3.0-0
 bioconductor-dupradar
 subread
+kallisto

--- a/workflows/mapping/config.yaml
+++ b/workflows/mapping/config.yaml
@@ -85,8 +85,11 @@ references:
   -
     assembly: 'hg19'
     type: 'fasta'
-    tag: 'gencode_v19_transcriptome'
-    url: 'ftp://ftp.sanger.ac.uk/pub/gencode/Gencode_human/release_19/gencode.v19.pc_transcripts.fa.gz'
+    tag: 'gencode_v19_plus_lncRNA_transcriptome'
+    url:
+      - 'ftp://ftp.sanger.ac.uk/pub/gencode/Gencode_human/release_19/gencode.v19.pc_transcripts.fa.gz'
+      - 'ftp://ftp.sanger.ac.uk/pub/gencode/Gencode_human/release_19/gencode.v19.lncRNA_transcripts.fa.gz'
+    postprocess: "hg19.plus_lncrna_fasta_postprocess"
     indexes:
       - 'kallisto'
   -

--- a/workflows/references/README.md
+++ b/workflows/references/README.md
@@ -87,8 +87,14 @@ importable by the `reference.snakefile`. The dotted name should refer to
 a function that has the function signature:
 
 ```python
-def func(downloaded_filename, postprocessed_filename)
+def func(temp_downloaded_filenames, final_postprocessed_filename)
 ```
+
+These two arguments are automatically provided by the references workflow --
+you don't have to know or care exactly what the filenames are, just what has to
+be done to their contents. The first argument is a list corresponding to the
+tempfiles downloaded for each provided url; the second is the final filename to
+create.
 
 The job of a postprocessing function is to ensure that the
 fastq/gtf/transcriptome fasta meets the requirements below and is ready for any

--- a/workflows/references/README.md
+++ b/workflows/references/README.md
@@ -1,10 +1,21 @@
 # References workflow
 
-## Quick start
+This workflow can be called from other workflows that depend on reference
+fastas, indexes, and annotations. In that case, rules in this workflow will
+only be run for those files asked for in the parent workflow.
+
+This workflow can also be called on its own, in which case it will build
+**all** of the references and indexes specified in the config. This can be
+helpful when setting up the workflows for the first time on a new machine. Run
+it like this:
 
 ```bash
-snakemake --configfile references_config.yaml -s references.snakefile
+snakemake -s references.snakefile --configfile ../mapping/config.yaml
 ```
+
+In both cases, it depends on the `references` section being in the global
+config dictionary; see below for details.
+
 ## Overview
 
 The references workflow is intended to be a universal workflow that supports
@@ -12,8 +23,8 @@ arbitrary genomes and results in FASTAs, indexes, annotations, and various
 processed versions of these files. It is based on the idea that while each
 genome's source files (FASTA, GTF) may come from different places and have
 slightly different formatting, once they are well-formatted they can be used to
-create a hisat2 index, a list of genes, and so on without any further
-customization.
+create a hisat2 index, a list of genes, intergenic regions, and so on without
+any further customization.
 
 The config file allows very flexible specification of how to
 create the files by providing a sort of plugin architecture.
@@ -25,6 +36,8 @@ for contamination).
 
 ```yaml
 
+# The following config is part of the main config.yaml, rather than
+# a standalone file
 
 data_dir: /data/LCDB/references
 references:
@@ -71,12 +84,12 @@ references:
 ```
 
 Each block describes either a fasta or gtf file. Each block has at least the
-assembly, type, and a URL.  They can also have a `postprocess`, which is an arbitrary
-function (described below) that converts the downloaded URL to something that
-conforms to the standards of the workflow (also described below). By supplying
-a tag, we can differentiate between different versions (e.g., FlyBase r6.04 vs
-r6.11) or different kinds of postprocessing (e.g, "chr" preprended to chrom
-names or not).
+assembly, type, and a URL.  They can also have a `postprocess`, which is an
+arbitrary function (described below) that converts the downloaded URL to
+something that conforms to the standards of the workflow (also described
+below). By supplying a tag, we can differentiate between different versions
+(e.g., FlyBase r6.04 vs r6.11) or different kinds of postprocessing (e.g, "chr"
+preprended to chrom names or not).
 
 Blocks with a type of "fasta" can have an optional  `indexes` entry which will
 build the specified indexes.
@@ -109,7 +122,7 @@ def fasta_postprocess(origfn, newfn):
 
 Note that the file is uncompressed in order to fix the chromosome naming and
 then recompressed into the final output. In this case the original file is
-removed.  We specify this function to be called in the fasta config block, like
+removed.  We specify this function to be called in the fasta config block like
 this (note that the module doesn't have to be the same name as the assembly,
 but it is here for clarity):
 
@@ -119,6 +132,10 @@ dm6:
     url: ...
     postprocess: "dm6.fasta_postprocess"
 ```
+
+This expects a file `dm6.py` in the same directory as the
+`references.snakefile` workflow, and expects a function `fasta_postprocess` to
+be defined in that module.
 
 Any downstream rules that operate on the genome FASTA file (like hisat2 index,
 bowtie2 index, etc) will now use this fixed version with "chr" prepended to

--- a/workflows/references/hg19.py
+++ b/workflows/references/hg19.py
@@ -1,0 +1,3 @@
+from snakemake.shell import shell
+def plus_lncrna_fasta_postprocess(tmpfiles, outfile):
+    shell('zcat {tmpfiles} > {outfile}')

--- a/workflows/references/references.snakefile
+++ b/workflows/references/references.snakefile
@@ -77,9 +77,9 @@ ext_mapping = {
     'fasta': '.fa.gz',
 }
 index_mapping = {
-    'bowtie2': ('{assembly}/bowtie2/{assembly}{tag}.{n}.bt2', dict(n=[1, 2, 3, 4])),
-    'hisat2': ('{assembly}/hisat2/{assembly}{tag}.{n}.ht2', dict(n=range(1, 9))),
-    'kallisto': ('{assembly}/kallisto/{assembly}{tag}.idx', dict()),
+    'bowtie2': ('{data_dir}/{assembly}/bowtie2/{assembly}{tag}.{n}.bt2', dict(n=[1, 2, 3, 4])),
+    'hisat2': ('{data_dir}/{assembly}/hisat2/{assembly}{tag}.{n}.ht2', dict(n=range(1, 9))),
+    'kallisto': ('{data_dir}/{assembly}/kallisto/{assembly}{tag}.idx', dict()),
 }
 references_targets = []
 for block in config['references']:
@@ -95,7 +95,7 @@ for block in config['references']:
         for index in indexes:
             pattern, kwargs = index_mapping[index]
             kwargs = kwargs.copy()
-            references_targets.extend(expand(pattern, assembly=assembly, tag=tag,  **kwargs))
+            references_targets.extend(expand(pattern, assembly=assembly, tag=tag, data_dir=data_dir, **kwargs))
 
 
 rule all_references:

--- a/workflows/references/references.snakefile
+++ b/workflows/references/references.snakefile
@@ -56,13 +56,14 @@ def download_and_postprocess(outfile):
         func = default_postprocess
     else:
         func = resolve_name(name)
-    url = block['url']
-    if outfile.endswith('.gz'):
-        gz = '.gz'
-    else:
-        gz = ''
-    shell("wget {url} -O- > {outfile}.tmp{gz}")
-    func(outfile + '.tmp' + gz, outfile)
+    urls = block['url']
+    if isinstance(urls, str):
+        urls = [urls]
+    tmpfiles = ['{0}.{1}.tmp'.format(outfile, i) for i in range(len(urls))]
+    for url, tmpfile in zip(urls, tmpfiles):
+        shell("wget {url} -O- > {tmpfile}")
+
+    func(tmpfiles, outfile)
 
 data_dir = config['data_dir']
 if not os.path.exists(data_dir):

--- a/workflows/references/sacCer3.py
+++ b/workflows/references/sacCer3.py
@@ -8,6 +8,10 @@ def fasta_postprocess(origfn, newfn):
     The fasta from UCSC comes as a tarball of fastas. So we extract them all to
     a temp directory and then cat them all together into the final fa.gz file.
     """
+    assert (
+        (isinstance(origfn, list)) and (len(origfn) == 1)
+    ), 'unexpected input: %s' % origfn
+    origfn = origfn[0]
     t = tarfile.open(origfn)
     shell('mkdir -p {origfn}.tmp')
     t.extractall(origfn + '.tmp')


### PR DESCRIPTION
- references snakefile can be run on its own to build all configured indexes etc
- updated README accordingly
- config now supports list of URLs. I needed this to be able to concatenate the human protein-coding and lncRNA transcriptome fastas, but it will be useful for ERCC spike-ins as well.
- added a first draft of lcdb-init.py which may eventually become the way we set up a new experiment
