### PR TITLE
Changes zcat to gunzip -c for OSX compatability.

### DIFF
--- a/workflows/references/dm6.py
+++ b/workflows/references/dm6.py
@@ -1,11 +1,11 @@
 from snakemake.shell import shell
 
 def fasta_postprocess(origfn, newfn):
-    shell("""zcat {origfn} | sed "s/>/>chr/g" | gzip -c > {newfn}  && rm {origfn}""")
+    shell("""gunzip -c {origfn} | sed "s/>/>chr/g" | gzip -c > {newfn}  && rm {origfn}""")
 
 def gtf_postprocess(origfn, newfn):
         shell(
-            "zcat {origfn} "
+            "gunzip -c {origfn} "
             """| awk -F "\\t" '{{OFS="\\t"; if ($8=="") $8="."; print "chr"$0}}' """
             "| gzip -c > {newfn} "
             "&& rm {origfn}")

--- a/workflows/references/hg19.py
+++ b/workflows/references/hg19.py
@@ -1,3 +1,3 @@
 from snakemake.shell import shell
 def plus_lncrna_fasta_postprocess(tmpfiles, outfile):
-    shell('zcat {tmpfiles} > {outfile}')
+    shell('gunzip -c {tmpfiles} > {outfile}')


### PR DESCRIPTION
The title says it all. For some reason OSX `zcat` does not behave as expected, but `gunzip -c` works. This seems to be a common problem. While not crucial, I am trying to maintain OSX compatibility as much as possible so the workflow can be more portable. For testing I suggest removing dm6 references and running:

``` bash
test/run_test.py . --workflow=workflows/mapping
```

Or if this is working

``` bash
test/run_test.py . --workflow=workflows/mapping --config=data_dir=/path/to/someother/location
```
