### PR TITLE
kallisto workflow

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -24,6 +24,7 @@ I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) source
 help:
 	@echo "Please use \`make <target>' where <target> is one of"
 	@echo "  html       to make standalone HTML files"
+	@echo "  dags       to build DAGs"
 	@echo "  dirhtml    to make HTML files named index.html in directories"
 	@echo "  singlehtml to make a single large HTML file"
 	@echo "  pickle     to make pickle files"
@@ -60,7 +61,7 @@ clean:
 # dag-building
 #
 # List of workflows for which we should build dag images
-WORKFLOWS = references mapping
+WORKFLOWS = references mapping kallisto
 
 # The config to use for building dags
 CONFIG = ../workflows/mapping/config.yaml
@@ -69,6 +70,7 @@ CONFIG = ../workflows/mapping/config.yaml
 RULEGRAPHPNGS = $(addprefix source/images/,$(addsuffix _dag.png,$(WORKFLOWS)))
 DAGPNGS = $(addprefix source/images/,$(addsuffix _full_dag.png,$(WORKFLOWS)))
 
+.PHONY: dags
 dags: $(DAGPNGS) $(RULEGRAPHPNGS)
 
 source/images/%_full_dag.png: ../workflows/%/Snakefile $(CONFIG)

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -21,6 +21,7 @@ Contents:
    testing
    config
    mapping
+   kallisto
    references
    metadocs
 

--- a/docs/source/kallisto.rst
+++ b/docs/source/kallisto.rst
@@ -1,0 +1,13 @@
+Kallisto workflow
+========+========
+
+.. figure:: images/kallisto_dag.png
+    :width: 400px
+
+    Rulegraph for kallisto workflow
+
+.. figure:: images/kallisto_full_dag.png
+    :width: 400px
+
+    Full DAG of jobs to run for kallisto workflow
+

--- a/lcdb/helpers.py
+++ b/lcdb/helpers.py
@@ -2,7 +2,7 @@ import os
 import pandas
 import yaml
 from jsonschema import validate, ValidationError
-
+from snakemake.shell import shell
 
 def validate_config(config, schema):
     schema = yaml.load(open(schema))
@@ -90,3 +90,26 @@ def load_sampletable(filename):
     """
     return pandas.read_table(filename, index_col=0)
 
+
+def rscript(string, scriptname, log=None):
+    """
+    Saves the string as `scriptname` and then runs it
+
+    Parameters
+    ----------
+    string : str
+        Filled-in template to be written as R script
+
+    scriptname : str
+        File to save script to
+
+    log : str
+        File to redirect stdout and stderr to. If None, no redirection occurs.
+    """
+    with open(scriptname, 'w') as fout:
+        fout.write(string)
+    if log:
+        _log = '> {0} 2>&1'.format(log)
+    else:
+        _log = ""
+    shell('Rscript {scriptname} {_log}')

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -13,4 +13,5 @@ picard>=2.3.0-0
 bioconductor-dupradar
 subread
 kallisto
+r-sleuth
 sphinx

--- a/workflows/kallisto/.gitignore
+++ b/workflows/kallisto/.gitignore
@@ -1,0 +1,2 @@
+references
+pasilla

--- a/workflows/kallisto/Snakefile
+++ b/workflows/kallisto/Snakefile
@@ -1,0 +1,104 @@
+# -*- snakemake -*-
+
+import yaml
+import itertools
+import pandas
+import sys
+from textwrap import dedent
+
+try:
+    config.update(yaml.load(open('config.yaml')))
+except IOError:
+    raise IOError('No "config.yaml" found; please supply another config '
+                  ' file using the --configfile argument')
+
+shell.prefix(config.get('shell_prefix', ''))
+
+# ----------------------------------------------------------------------------
+# Helper functions
+#
+HERE = srcdir('')
+WRAPPERS = '../../wrappers'
+sys.path.insert(0, os.path.join(HERE, '../../lcdb'))
+import helpers
+wrapper_for, params_for, threads_for = helpers.workflow_helper_functions(config, HERE, WRAPPERS)
+
+from interface import SampleHandler
+
+
+sampletable = helpers.load_sampletable(config['sampletable'])
+samples = sampletable.index.tolist()
+
+include: '../references/Snakefile'
+
+# ----------------------------------------------------------------------------
+# Generate final targets
+#
+patterns = [
+    '{{sample_dir}}/{{sampleID}}/kallisto/abundance.h5',
+    '{{sample_dir}}/kallisto/sampletable.tsv',
+    '{{sample_dir}}/kallisto/results.txt',
+]
+# ----------------------------------------------------------------------------
+
+SH = SampleHandler(config)
+
+targets = SH.build_targets(patterns)
+rule all:
+    input: targets
+
+
+rule clean:
+    run:
+        if os.path.exists(config['sample_dir']):
+            shell('rm -r {config[sample_dir]}')
+        shell('wget -O - http://helix.nih.gov/~dalerr/lcdb-workflows-data/pasilla.tar > pasilla.tar')
+        shell('tar -xvf pasilla.tar')
+        shell('rm pasilla.tar')
+
+rule kallisto_quant:
+    input:
+        fastq="{sample_dir}/{sample}/{sample}_R1.fastq.gz",
+        index=os.path.join(config['data_dir'], config['rules']['kallisto_quant']['index'])
+    output: "{sample_dir}/{sample}/kallisto/abundance.h5"
+    params: extra=config['rules']['kallisto_quant']['params']['extra']
+    wrapper:
+        wrapper_for('kallisto/kallisto-quant')
+
+rule kallisto_sampletable:
+    input: config['sampletable']
+    output: '{sample_dir}/kallisto/sampletable.tsv'
+    run:
+        df = pandas.read_table(input[0], sep='\t')
+        def path(x):
+            return rules.kallisto_quant.output[0].format(
+                sample_dir=config['sample_dir'], sample=x)
+        df['path'] = df.sampleID.apply(path)
+        cols = list(df.columns)
+        cols[0] = 'sample'
+        df.columns = cols
+        df.to_csv(output[0], sep='\t', index=False)
+
+rule sleuth:
+    input:
+        sampletable=rules.kallisto_sampletable.output,
+        quant=[i for i in targets if i.endswith('abundance.h5')]
+    output:
+        results='{sample_dir}/kallisto/results.txt',
+        script='{sample_dir}/kallisto/script.R',
+    log: '{sample_dir}/kallisto/results.log'
+    run:
+        template = dedent(r"""
+        library(sleuth)
+        s2c <- read.table('{input.sampletable}', sep='\t', header=T, stringsAsFactors=F)
+        so <- sleuth_prep(s2c, {config[rules][sleuth][model]})
+        so <- sleuth_fit(so)
+        so <- sleuth_fit(so, ~1, 'reduced')
+        so <- sleuth_lrt(so, 'reduced', 'full')
+        results_table <- sleuth_results(so, 'reduced:full', test_type='lrt')
+        write.table(results_table, file='{output.results}', sep='\t')
+        """).format(config=config, **locals())
+
+        helpers.rscript(template, output.script, log)
+
+# vim: ft=python

--- a/workflows/kallisto/config.yaml
+++ b/workflows/kallisto/config.yaml
@@ -1,0 +1,40 @@
+sampletable: pasilla_sampletable.tsv
+sample_dir: pasilla
+assembly: dm6
+data_dir: references
+
+rawLevel: 'pasilla/{sampleID}/{sampleID}_R1'
+runLevel: 'pasilla/{sampleID}/{sampleID}_R1'
+sampleLevel: 'pasilla/{sampleID}/{sampleID}'
+aggLevel: 'pasilla/agg/{treatment}'
+
+shell_prefix: "source lcdb-workflows.bashrc; "
+cluster_default:
+  args: "--time=04:00:00"
+
+rules:
+  kallisto_quant:
+    index: 'dm6/kallisto/dm6_r6-11_transcriptome.idx'
+    params:
+      extra: '--single --fragment-length=200 --sd=20 --bootstrap-samples=100'
+
+  sleuth:
+    model: "~treatment"
+
+references:
+
+  -
+    assembly: 'dm6'
+    type: 'gtf'
+    url: 'ftp://ftp.flybase.net/genomes/Drosophila_melanogaster/current/gtf/dmel-all-r6.11.gtf.gz'
+    postprocess: "dm6.gtf_postprocess"
+    tag: 'r6-11'
+    conversions:
+      - 'intergenic'
+  -
+    assembly: 'dm6'
+    type: 'fasta'
+    tag: 'r6-11_transcriptome'
+    url: 'ftp://ftp.flybase.net/genomes/Drosophila_melanogaster/current/fasta/dmel-all-transcript-r6.11.fasta.gz'
+    indexes:
+      - 'kallisto'

--- a/workflows/kallisto/get-data.sh
+++ b/workflows/kallisto/get-data.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+
+HERE=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+
+cd $HERE
+if [ ! -e pasilla ]; then
+    wget http://helix.nih.gov/~dalerr/lcdb-workflows-data/pasilla.tar
+    tar -xvf pasilla.tar
+    rm pasilla.tar
+else
+    echo "'pasilla' directory already exists"
+fi

--- a/workflows/kallisto/lcdb-workflows.bashrc
+++ b/workflows/kallisto/lcdb-workflows.bashrc
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+if [ -n "$SLURM_JOBID" ]; then
+    export TMPDIR="/lscratch/$SLURM_JOBID"
+fi

--- a/workflows/kallisto/pasilla/get-data.bash
+++ b/workflows/kallisto/pasilla/get-data.bash
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# Downloads data used in the pasilla R package . . . but only the first 250k
+# reads on chr2L.
+
+set -e 
+set -o pipefail
+HERE=$(pwd)
+CHROM="chr2L"
+NREADS=250000
+for i in \
+    treated1 \
+    treated2 \
+    treated3 \
+    untreated1 \
+    untreated2 \
+    untreated3 \
+    untreated4 \
+; do
+    echo "${i}"
+    mkdir -p "${i}"
+    cd "${HERE}/${i}"
+    if [ -e "${i}_R1.fastq" ]; then
+        echo "${i}_R1.fastq exists; skipping"
+    else
+        samtools view -b "http://www-huber.embl.de/pub/DEXSeq/analysis/brooksetal/bam/${i}.bam" "$CHROM" \
+            | bedtools sample -i stdin -n "$NREADS" \
+            | bedtools bamtofastq -i stdin -fq "${i}.fastq.tmp" && mv "${i}.fastq.tmp" "${i}_R1.fastq" && rm ${i}.bam.bai
+    fi
+    cd ${HERE}
+done
+

--- a/workflows/kallisto/pasilla_sampletable.tsv
+++ b/workflows/kallisto/pasilla_sampletable.tsv
@@ -1,0 +1,5 @@
+sampleID	treatment	replicate
+treated1	treated	1
+treated2	treated	2
+untreated1	untreated	1
+untreated2	untreated	2

--- a/wrappers/kallisto/README.md
+++ b/wrappers/kallisto/README.md
@@ -1,0 +1,4 @@
+Kallisto quantifies reads in transcripts.
+
+It has two main programs: `index` and `quant`; you can read more about them in
+their respective READMEs.

--- a/wrappers/kallisto/kallisto-quant/README.md
+++ b/wrappers/kallisto/kallisto-quant/README.md
@@ -1,0 +1,79 @@
+# Wrapper for *kallisto quant*
+
+
+[Kallisto home](https://pachterlab.github.io/kallisto/)
+
+[Kallisto manual](https://pachterlab.github.io/kallisto/manual)
+
+
+## Input
+
+* `index`: kallisto index file
+* `fastq`: either a pair of PE fastqs or a single fastq. If single, see note in Params section.
+
+## Output
+
+`kallisto quant` outputs files hard-coded as:
+
+```
+outfile/
+├── abundance.h5
+├── abundance.tsv
+└── run_info.json
+```
+
+Since the downstream `sleuth` tool expects these names, we do not move them. It
+is recommended that you use the sample name in the directory (see example
+below). The wrapper detects the output directory from the first output file;
+the rest of the output files are optional.
+
+## Threads
+
+Threads are passed as the `--threads` argument to kallisto quant.
+
+## Params
+
+* `extra`: passed verbatim to kallisto quant
+
+NOTE: if you are using single-end reads, then kallisto will complain if you
+don't set the `--fragment-length` and `--sd` params. Add them to extra. Based
+on [this
+comment](https://groups.google.com/forum/#!searchin/kallisto-sleuth-users/sd/kallisto-sleuth-users/VPJfzL502bw/e2JDq7ezBgAJ)
+from the author, `--fragment-length=200 --sd=20` should be a good starting
+point.
+
+NOTE: if you plan on using `sleuth` for differential expression, you'll want to
+include the `--bootstrap-samples` argument.
+
+## Example
+
+Single-end reads example, with all output files specified (only one is required
+for the wrapper to identify the output directory), log, and `extra` params:
+
+```python
+rule kallisto_quant:
+    input:
+        fastq="{sample}.fastq.gz",
+        index="references/dm6/kallisto.idx"
+    output:
+        "quant/kallisto/{sample}/abundance.h5",
+        "quant/kallisto/{sample}/abundance.tsv",
+        "quant/kallisto/{sample}/run_info.json"
+    log: "quant/kallisto/{sample}/kallisto.log"
+    params: extra="--fragment-length=200 --sd=20 --single"
+    wrapper:
+        "/path/to/wrapper/location"
+```
+
+Paired-end, simplified example:
+
+```python
+rule kallisto_quant:
+    input:
+        fastq=["{sample}_R1.fastq.gz", "{sample}_R2.fastq.gz"]
+        index="references/dm6/kallisto.idx"
+    output:
+        "quant/kallisto/{sample}/abundance.h5",
+    wrapper:
+        "/path/to/wrapper/location"
+```

--- a/wrappers/kallisto/kallisto-quant/environment.yaml
+++ b/wrappers/kallisto/kallisto-quant/environment.yaml
@@ -1,0 +1,4 @@
+channels:
+  - bioconda
+dependencies:
+  - kallisto

--- a/wrappers/kallisto/kallisto-quant/wrapper.py
+++ b/wrappers/kallisto/kallisto-quant/wrapper.py
@@ -1,0 +1,28 @@
+__author__ = "Ryan Dale"
+__copyright__ = "Copyright 2016, Ryan Dale"
+__email__ = "dalerr@niddk.nih.gov"
+__license__ = "MIT"
+
+import os
+from snakemake.shell import shell
+
+try:
+    extra = snakemake.params.extra
+except AttributeError:
+    extra = ""
+
+if snakemake.log:
+    log = "> {} 2>&1".format(snakemake.log)
+else:
+    log = ""
+
+outdir = os.path.dirname(snakemake.output[0])
+
+shell(
+    "kallisto quant "
+    "--index {snakemake.input.index} "
+    "-o {snakemake.output} "
+    "--threads {snakemake.threads} "
+    "{extra} "
+    "{snakemake.input.fastq} "
+    "{log} ")


### PR DESCRIPTION
This PR adds a kallisto workflow. It runs `kallisto quant` on all samples and then runs `sleuth` for differential expression.

`sleuth` is an R package, and the sleuth rule is an example of running a customized R script. So there is a new `helpers.rscript` function that writes and runs the filled-in-template. This is because I like having the script available for later debugging/tweaking. I'm still trying to figure out it it's worth it to put sleuth into a wrapper or not.

Also note that the model for sleuth is specified in the config file.

kallisto is kind of annoying because if you want to use the downstream sleuth package, you need to have particularly-named files. See the kallisto quant readme for details. This kind of breaks the existing SampleHandler class system, hence the double-brackets in the patterns.

Not sure I'm happy with the output organization or with the R script handling, but it works. Please take a look and see what you think. Next step will be reporting.

Test it with:

``` bash
test/run_test.py --build-env --cluster workflows/kallisto/Snakefile
```
