### PR TITLE
Updates dm6 download URL from current to FB2016_03

### DIFF
--- a/workflows/kallisto/config.yaml
+++ b/workflows/kallisto/config.yaml
@@ -26,7 +26,7 @@ references:
   -
     assembly: 'dm6'
     type: 'gtf'
-    url: 'ftp://ftp.flybase.net/genomes/Drosophila_melanogaster/current/gtf/dmel-all-r6.11.gtf.gz'
+    url: 'ftp://ftp.flybase.net/genomes/Drosophila_melanogaster/dmel_r6.11_FB2016_03/gtf/dmel-all-r6.11.gtf.gz'
     postprocess: "dm6.gtf_postprocess"
     tag: 'r6-11'
     conversions:
@@ -35,6 +35,6 @@ references:
     assembly: 'dm6'
     type: 'fasta'
     tag: 'r6-11_transcriptome'
-    url: 'ftp://ftp.flybase.net/genomes/Drosophila_melanogaster/current/fasta/dmel-all-transcript-r6.11.fasta.gz'
+    url: 'ftp://ftp.flybase.net/genomes/Drosophila_melanogaster/dmel_r6.11_FB2016_03/fasta/dmel-all-transcript-r6.11.fasta.gz'
     indexes:
       - 'kallisto'

--- a/workflows/mapping/config.yaml
+++ b/workflows/mapping/config.yaml
@@ -64,14 +64,14 @@ references:
   -
     assembly: 'dm6'
     type: 'gtf'
-    url: 'ftp://ftp.flybase.net/genomes/Drosophila_melanogaster/current/gtf/dmel-all-r6.11.gtf.gz'
+    url: 'ftp://ftp.flybase.net/genomes/Drosophila_melanogaster/dmel_r6.11_FB2016_03/gtf/dmel-all-r6.11.gtf.gz'
     postprocess: "dm6.gtf_postprocess"
     tag: 'r6-11'
     conversions:
       - 'intergenic'
   -
     assembly: 'dm6'
-    url: 'ftp://ftp.flybase.net/genomes/Drosophila_melanogaster/current/fasta/dmel-all-chromosome-r6.11.fasta.gz'
+    url: 'ftp://ftp.flybase.net/genomes/Drosophila_melanogaster/dmel_r6.11_FB2016_03/fasta/dmel-all-chromosome-r6.11.fasta.gz'
     postprocess: "dm6.fasta_postprocess"
     type: 'fasta'
     indexes:
@@ -81,7 +81,7 @@ references:
     assembly: 'dm6'
     type: 'fasta'
     tag: 'r6-11_transcriptome'
-    url: 'ftp://ftp.flybase.net/genomes/Drosophila_melanogaster/current/fasta/dmel-all-transcript-r6.11.fasta.gz'
+    url: 'ftp://ftp.flybase.net/genomes/Drosophila_melanogaster/dmel_r6.11_FB2016_03/fasta/dmel-all-transcript-r6.11.fasta.gz'
     indexes:
       - 'kallisto'
   -


### PR DESCRIPTION
Flybase just release 6.12. In the config files the url pointed to the 'current' directory which now has 6.12 and not 6.11. Fixed url to point to 6.11.
